### PR TITLE
Small fixes to Lime implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,7 +432,7 @@ endif(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clan
 ADD_C_COMPILER_FLAG_IF_AVAILABLE("-Werror=incompatible-pointer-types" HAVE_ERROR_INCOMPATIBLE)
 
 if(CMAKE_C_COMPILER_ID MATCHES "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-comment -Wno-write-strings -Wno-unused-result -Wformat -Wmissing-field-initializers -Wtype-limits -std=c99 -fno-strict-aliasing -D_GNU_SOURCE")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-comment -Wno-write-strings -Wno-unused-result -Wformat -Wmissing-field-initializers -Wtype-limits -Wno-stringop-overflow -Wno-stringop-overread -std=c99 -fno-strict-aliasing -D_GNU_SOURCE")
 
   ADD_C_COMPILER_FLAG_IF_AVAILABLE("-Wno-unused-but-set-variable" HAVE_WNO_UNUSED_BUT_SET_VARIABLE)
   if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")

--- a/lib/src/phy/rf/rf_lime_imp.c
+++ b/lib/src/phy/rf/rf_lime_imp.c
@@ -73,7 +73,7 @@ typedef struct {
   pthread_t async_thread;
 } rf_lime_handler_t;
 
-cf_t zero_mem[64 * 1024];
+static cf_t zero_mem[64 * 1024];
 
 #if HAVE_ASYNC_THREAD
 static void log_overflow(rf_lime_handler_t* h)

--- a/lib/src/phy/rf/rf_lime_imp.h
+++ b/lib/src/phy/rf/rf_lime_imp.h
@@ -82,7 +82,7 @@ SRSRAN_API int
 rf_lime_recv_with_time(void* h, void* data, uint32_t nsamples, bool blocking, time_t* secs, double* frac_secs);
 
 SRSRAN_API int
-rf_lime_recv_with_time_multi(void* h, void** data, uint32_t nsamples, bool blocking, time_t* secs, double* frac_secs);
+rf_lime_recv_with_time_multi(void* h, void* data[4], uint32_t nsamples, bool blocking, time_t* secs, double* frac_secs);
 
 SRSRAN_API double rf_lime_set_tx_srate(void* h, double freq);
 


### PR DESCRIPTION
* Suppress known overzealous warnings in later GCC
* Fix mismatched function signatures